### PR TITLE
Potential fix for code scanning alert no. 61: Equals should not apply "is"

### DIFF
--- a/Contracts/Graph/CodeElement.cs
+++ b/Contracts/Graph/CodeElement.cs
@@ -28,8 +28,9 @@ public class CodeElement(string id, CodeElementType elementType, string name, st
 
     public override bool Equals(object? obj)
     {
-        if (obj is CodeElement other)
+        if (obj != null && obj.GetType() == GetType())
         {
+            var other = (CodeElement)obj;
             return Id == other.Id;
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/ATrefzer/CSharpCodeAnalyst/security/code-scanning/61](https://github.com/ATrefzer/CSharpCodeAnalyst/security/code-scanning/61)

To fix the problem, we need to ensure that `Equals` will only return `true` if `obj` is an instance of exactly the same type as the current object (`this`). Rather than using `obj is CodeElement other`, we should check `obj != null && obj.GetType() == GetType()`, then safely cast `obj` to `CodeElement`. This ensures our `Equals` implementation is symmetric and only returns `true` for objects of the exact same class, with matching `Id`.

**How to fix:**
- In the `Equals` method, replace the line `if (obj is CodeElement other)` with a type and null check.
- If the type matches, explicitly cast `obj` to `CodeElement` using a direct cast.

**Required changes:**
- Edit the `Equals` override inside `CodeElement` (lines 29–37).
- No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
