### PR TITLE
Fix documentation errors and UI inconsistencies

### DIFF
--- a/CSharpCodeAnalyst/Configuration/SettingsDialog.xaml
+++ b/CSharpCodeAnalyst/Configuration/SettingsDialog.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:resources="clr-namespace:CSharpCodeAnalyst.Resources"
-        Title="Settings" Height="400" Width="500"
+        Title="Settings" Height="450" Width="500"
         SizeToContent="WidthAndHeight"
         MinWidth="400"
         MinHeight="430"

--- a/CSharpCodeAnalyst/Features/Info/InfoPanel.xaml
+++ b/CSharpCodeAnalyst/Features/Info/InfoPanel.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:converters="clr-namespace:CSharpCodeAnalyst.Shared.Converters"
              xmlns:info="clr-namespace:CSharpCodeAnalyst.Features.Info"
+             xmlns:resources="clr-namespace:CSharpCodeAnalyst.Resources"
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance info:InfoPanelViewModel}"
              d:DesignHeight="450" d:DesignWidth="300">
@@ -60,7 +61,7 @@
                         <!-- Another list for the source code -->
                         <StackPanel Orientation="Vertical"
                                     Visibility="{Binding SourceLocations.Count, Converter={StaticResource NumberToVisibilityConverter}}">
-                            <TextBlock Text="Locations" FontWeight="Bold" Margin="0 10 0 0" />
+                            <TextBlock Text="{x:Static resources:Strings.Locations_Label}" FontWeight="Bold" Margin="0 10 0 0" />
                             <ItemsControl ItemsSource="{Binding SourceLocations}"
                                           ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                           ScrollViewer.VerticalScrollBarVisibility="Disabled"

--- a/CSharpCodeAnalyst/Features/Tree/TreeControl.xaml
+++ b/CSharpCodeAnalyst/Features/Tree/TreeControl.xaml
@@ -65,7 +65,7 @@
                   Margin="5"
                   dd:DragDrop.IsDragSource="True">
 
-            <!-- Note: The TreeVie SelectedItem is not a DependencyProperty, so we need to use
+            <!-- Note: The TreeView SelectedItem is not a DependencyProperty, so we need to use
             an Interaction Trigger to bind it to the ViewModel -->
             <b:Interaction.Triggers>
                 <b:EventTrigger EventName="SelectedItemChanged">

--- a/CSharpCodeAnalyst/MainWindow.xaml
+++ b/CSharpCodeAnalyst/MainWindow.xaml
@@ -107,7 +107,7 @@
 
                 </RibbonGroup>
 
-                <RibbonGroup Header="Tools" LargeImageSource="/Resources/cycle_32.png">
+                <RibbonGroup Header="{x:Static resources:Strings.Tools_Header}" LargeImageSource="/Resources/cycle_32.png">
                     <RibbonButton Label="{x:Static resources:Strings.Find_Cycles_Label}"
                                   LargeImageSource="/Resources/cycle_32.png"
                                   Command="{Binding FindCyclesCommand}" KeyTip="CY" />
@@ -167,7 +167,7 @@
                     </RibbonButton>
 
 
-                    <RibbonSplitButton Label="Export"
+                    <RibbonSplitButton Label="{x:Static resources:Strings.Export_Label}"
                                        LargeImageSource="/Resources/document-xml_32.png"
                                        Command="{Binding ExportToDgmlCommand}" KeyTip="EX">
 
@@ -246,10 +246,6 @@
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-
-                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
 
                         <RibbonToggleButton HorizontalAlignment="Left"
@@ -308,7 +304,7 @@
                 </RibbonGroup>
 
                 <!-- Helpers Ribbon Group -->
-                <RibbonGroup Header="Helpers"
+                <RibbonGroup Header="{x:Static resources:Strings.Helpers_Header}"
                              LargeImageSource="/Resources/snapshot_32.png">
                     <RibbonButton Label="{x:Static resources:Strings.Snapshot}"
                                   LargeImageSource="/Resources/snapshot_32.png"
@@ -382,7 +378,7 @@
                 </TabControl>
             </Expander>
 
-            <!-- If the expander is collapse we don't show the splitter-->
+            <!-- If the expander is collapsed we don't show the splitter-->
             <GridSplitter Grid.Column="1"
                           Width="5"
                           HorizontalAlignment="Center"

--- a/CSharpCodeAnalyst/Resources/Strings.Designer.cs
+++ b/CSharpCodeAnalyst/Resources/Strings.Designer.cs
@@ -108,7 +108,7 @@ namespace CSharpCodeAnalyst.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to AI Advise.
+        ///   Looks up a localized string similar to AI Advisor.
         /// </summary>
         public static string AiAdvise_Label {
             get {
@@ -585,7 +585,7 @@ namespace CSharpCodeAnalyst.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Copy to image to clipboard.
+        ///   Looks up a localized string similar to Copy image to clipboard.
         /// </summary>
         public static string Copy_BitmapClipboard_Label {
             get {
@@ -774,6 +774,15 @@ namespace CSharpCodeAnalyst.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Export.
+        /// </summary>
+        public static string Export_Label {
+            get {
+                return ResourceManager.GetString("Export_Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Export DGML ....
         /// </summary>
         public static string ExportDgml_Label {
@@ -819,7 +828,7 @@ namespace CSharpCodeAnalyst.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CExport Code Explorer (expanded) graph to plain text..
+        ///   Looks up a localized string similar to Export Code Explorer (expanded) graph to plain text..
         /// </summary>
         public static string ExportPlainText_Tooltip {
             get {
@@ -1130,6 +1139,15 @@ namespace CSharpCodeAnalyst.Resources {
         public static string Help_Header {
             get {
                 return ResourceManager.GetString("Help_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Helpers.
+        /// </summary>
+        public static string Helpers_Header {
+            get {
+                return ResourceManager.GetString("Helpers_Header", resourceCulture);
             }
         }
         

--- a/CSharpCodeAnalyst/Resources/Strings.resx
+++ b/CSharpCodeAnalyst/Resources/Strings.resx
@@ -680,7 +680,7 @@ Search with resharper style = Use at least one uppercase character in a search t
   </data>
 
     <data name="Copy_BitmapClipboard_Label" xml:space="preserve">
-    <value>Copy to image to clipboard</value>
+    <value>Copy image to clipboard</value>
   </data>
     <data name="Copy_BitmapClipboard_Tooltip" xml:space="preserve">
     <value>Copy current Code Explorer graph as image to clipboard.</value>
@@ -689,7 +689,7 @@ Search with resharper style = Use at least one uppercase character in a search t
     <value>Export plain text ...</value>
   </data>
     <data name="ExportPlainText_Tooltip" xml:space="preserve">
-    <value>CExport Code Explorer (expanded) graph to plain text.</value>
+    <value>Export Code Explorer (expanded) graph to plain text.</value>
   </data>
     <data name="ExportSvg_Tooltip" xml:space="preserve">
     <value>Export Code Explorer (expanded) graph to SVG. NOTE: Sub-graphs are not implemented!</value>
@@ -893,6 +893,12 @@ ISOLATE: MyApp.Domain.**</value>
     <data name="Import_Label" xml:space="preserve">
     <value>Import</value>
   </data>
+    <data name="Export_Label" xml:space="preserve">
+    <value>Export</value>
+  </data>
+    <data name="Helpers_Header" xml:space="preserve">
+    <value>Helpers</value>
+  </data>
     <data name="Settings_Header_Tooltip" xml:space="preserve">
     <value>Open application settings dialog</value>
   </data>
@@ -1007,7 +1013,7 @@ ISOLATE: MyApp.Domain.**</value>
     <value>Your API key. It is encrypted with Windows DPAPI and stored locally — only the current Windows user can read it.</value>
   </data>
     <data name="AiAdvise_Label" xml:space="preserve">
-    <value>AI Advise</value>
+    <value>AI Advisor</value>
   </data>
     <data name="AiAdvise_Tooltip" xml:space="preserve">
     <value>Ask AI for suggestions on how to resolve the cycle in the current graph</value>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # C# Code Analyst
 
-[TOC]
-
 This application helps you to explore, understand, and maintain C# code.
 
 Here is a [presentation on YouTube](https://www.youtube.com/watch?v=o_r1CdQy0tY) on using the application to analyze cyclic dependencies.
@@ -81,9 +79,9 @@ Remember, the goal isn't to eliminate every cycle but to be aware of your code's
 
 **In general, it's a good guideline to keep your software system free of cycles at the namespace level.**
 
-### AI Advise
+### AI Advisor
 
-Once you have loaded a cycle group into the Code Explorer, the **AI Advise** button in the toolbar sends the cycle to a configured LLM and asks it for ideas on how to resolve or break down the dependency cycle.
+Once you have loaded a cycle group into the Code Explorer, the **AI Advisor** button in the toolbar sends the cycle to a configured LLM and asks it for ideas on how to resolve or break down the dependency cycle.
 
 To use this feature, open **Settings** and enter your API endpoint and key. The tool supports any OpenAI-compatible endpoint, including local models (e.g. Ollama) and Anthropic's API.
 
@@ -188,15 +186,11 @@ Select "Copy to PlantUml class diagram" from the Export menu.
 
 
 
-The PlantUml syntax is copied to the clipboard. You can use any online online editor to render it.
+The PlantUml syntax is copied to the clipboard. You can use any online editor to render it.
 
 
 
 ![](Documentation/Images/example-uml.png)
-
-## Performance Tips
-
-When the graph contains more than ~200 code elements, performance slows down. However, viewing so many elements at once is not helpful. You can collapse and expand container elements by double-clicking them to minimize the number of visible elements. When using the Advanced Search to add multiple code elements, consider adding them in a collapsed state to maintain focus and start with a smaller, faster graph.
 
 ## Other languages
 


### PR DESCRIPTION
- README: remove duplicate [TOC], fix double 'online', remove duplicate Performance Tips section, rename 'AI Advise' -> 'AI Advisor' throughout
- Strings.resx: fix 'CExport' typo, 'Copy to image' -> 'Copy image', rename AiAdvise_Label to 'AI Advisor'; add Export_Label and Helpers_Header
- MainWindow.xaml: replace hardcoded 'Tools', 'Helpers', 'Export' strings with resource bindings; fix comment typo; remove unused RowDefinitions
- SettingsDialog.xaml: fix Height (400) < MinHeight (430) contradiction
- InfoPanel.xaml: add resources namespace, use Strings.Locations_Label instead of hardcoded 'Locations' string
- TreeControl.xaml: fix 'TreeVie' typo in comment

https://claude.ai/code/session_011QMVhyH8xEWBZqhHMqk4yk