### PR TITLE
Share multi-source CI pipeline pattern (headless validate + evidence hub)

### DIFF
--- a/Documentation/architectural-rules.md
+++ b/Documentation/architectural-rules.md
@@ -127,3 +127,5 @@ Over time, after refactoring or deleting baselined elements, some rules might no
 To integrate the tool into a build pipeline, you can call it without a user interface. You can find the syntax of the command-line here:
 
 [Command-line arguments](command-line-arguments.md)
+
+For multi-source CI packaging and an evidence-edge merge model, see [CI + multi-source evidence pipeline](ci-and-multi-source-pipeline.md).

--- a/Documentation/ci-and-multi-source-pipeline.md
+++ b/Documentation/ci-and-multi-source-pipeline.md
@@ -1,0 +1,172 @@
+# CI + multi-source evidence pipeline
+
+[TOC]
+
+C# Code Analyst’s headless `-validate` mode is a **structural** auditor: DENY/RESTRICT layers, NOCYCLES, MAXCYCLICITY, LOC budgets. That is exactly what most teams need for CI guardrails.
+
+Used alone, though, `-validate` answers one question ("does this dependency graph violate these rules?"). Large products usually need more than one instrument. This document describes a **multi-source pipeline** pattern: treat Code Analyst as one evidence stage among peers, merge results with explicit **tensions**, and only then form product decisions.
+
+The pattern is intentionally generic. Teams wire different importers (UI binders, DI graphs, shell maps, hotspots). The CI recipe and edge model still work if your only importer is Code Analyst.
+
+Related:
+
+- [Command-line arguments](command-line-arguments.md)
+- [Architectural rules](architectural-rules.md)
+- Sample pack: [`samples/ci-pipeline/`](../samples/ci-pipeline/README.md)
+
+---
+
+## 1. What Code Analyst proves (and what it does not)
+
+| Proved well | Often invisible |
+|-------------|-----------------|
+| Layer rules (`DENY Core.** -> UI.**`) | Avalonia / WPF bindings that only live in markup |
+| Type-graph cyclicity (`MAXCYCLICITY`, `NOCYCLES`) | DI registrations that never appear as ordinary C# calls |
+| ViewModel → View construction edges (when C# constructs views) | Dynamic feature loading, reflection |
+| Metric budgets (`MAXLINES`) | Runtime shell tab routes (`DataTemplate` / content presenters) |
+
+**Hard lesson from Avalonia (and similar UI stacks):** the parse log can report  
+`Reading XAML references: … (0 relationships)`.  
+Shell routes that exist only as markup are **open circuits** in the Roslyn graph. A type with fan-in 0 can still be LIVE in the product.
+
+**Doctrine:** Code Analyst audits **layers and cycles**. Route/bind truth needs a peer auditor (hand-maintained map, UI binding scanner, integration tests). Do not let a green `-validate` exit code declare "wiring is healthy."
+
+---
+
+## 2. Pipeline shape
+
+```text
+┌──────────────────┐   ┌───────────────────┐   ┌────────────────────┐
+│  Code Analyst    │   │  Peer importers   │   │  Other instruments │
+│  -validate rules │   │  (UI, DI, shell)  │   │  (hotspots, tests) │
+└────────┬─────────┘   └─────────┬─────────┘   └──────────┬─────────┘
+         │                       │                        │
+         └───────────┬───────────┴────────────┬───────────┘
+                     ▼                        ▼
+              handoff JSON (per source)     raw reports
+                     │
+                     ▼
+              merge: edges + tensions (never silent overwrite)
+                     │
+         ┌───────────┴───────────┐
+         ▼                       ▼
+    graph.ssot.jsonl        dashboard.md / CI summary
+```
+
+### Rules of the merge
+
+1. **Every edge is tagged** with `evidence_source` (e.g. `codeanalyst`, `ui_bindings`, `di_factory`).
+2. **No importer deletes another importer’s edges.** When two sources disagree, emit a `tension` edge or status instead of picking a winner.
+3. **Always run the full hub you claim to run.** Partial slices look green and lie.
+4. **CI may fail on selected kinds only** (e.g. new DENY edges / NOCYCLES) while still *recording* softer sources for humans.
+
+---
+
+## 3. Evidence edge (minimal contract)
+
+A portable edge is a small JSON object. Full sample schema: [`samples/ci-pipeline/schema/edge.schema.json`](../samples/ci-pipeline/schema/edge.schema.json).
+
+```json
+{
+  "kind": "layer_deny",
+  "from": "MyApp.Core.Services.OrderService",
+  "to": "MyApp.UI.ViewModels.OrderViewModel",
+  "evidence_source": "codeanalyst",
+  "status": "DENY",
+  "confidence": 0.95,
+  "path": "artifacts/codeanalyst/validation-result.txt",
+  "note": "DENY Core.** -> UI.**"
+}
+```
+
+Suggested kinds for Code Analyst output:
+
+| Result block | kind | status |
+|--------------|------|--------|
+| `DENY` edges | `layer_deny` | `DENY` |
+| `NOCYCLES` groups | `cycle` | `WARN` |
+| Metric overages | `metric` | `WARN` or `FAIL` |
+
+Peer importers introduce their own kinds (`bind`, `inject`, `shell_route`, …). Merge keeps them all.
+
+---
+
+## 4. CI integration (headless)
+
+### Exit codes (Code Analyst)
+
+| Code | Meaning |
+|------|---------|
+| 0 | No rule violations |
+| 1 | Violations found |
+| 2 | Validation failed (load/parse error) |
+
+### Minimal job (release zip)
+
+Windows runners only (app targets `net10.0-windows`).
+
+```yaml
+- name: Download C# Code Analyst release
+  shell: pwsh
+  run: |
+    $url = "https://github.com/ATrefzer/CSharpCodeAnalyst/releases/latest/download/latest-release.zip"
+    Invoke-WebRequest $url -OutFile codeanalyst.zip
+    Expand-Archive codeanalyst.zip -DestinationPath tools/codeanalyst -Force
+
+- name: Validate architecture
+  shell: pwsh
+  run: |
+    & tools/codeanalyst/CSharpCodeAnalyst.exe `
+      -validate `
+      -sln:${{ github.workspace }}/MyApp.sln `
+      -rules:${{ github.workspace }}/architecture.rules.txt `
+      -log-console `
+      -out:${{ github.workspace }}/artifacts/codeanalyst/validation-result.txt
+  # Optional: continue-on-error: true when you only want artifacts, not a red build
+```
+
+The composite action under [`samples/ci-pipeline/action/`](../samples/ci-pipeline/action/action.yml) packages this as a reusable step.
+
+### Parse → structured edges
+
+Headless output is currently **human-readable text**. The sample parser  
+[`samples/ci-pipeline/scripts/parse_validation_result.py`](../samples/ci-pipeline/scripts/parse_validation_result.py) turns it into JSON edges + a handoff summary suitable for a multi-source merge.
+
+> Wish for upstream later: a first-class `-out-json:<file>` (or SARIF) export would remove the text scrape. Until then, parsers stay tolerant of whitespace noise.
+
+---
+
+## 5. Rules file hygiene for monorepos
+
+1. Discover path prefixes interactively first (Tree View / advanced search), then write `DENY` / `NOCYCLES` with the **exact** assembly + namespace form the graph uses.
+2. Wrong prefixes often **silently no-op** (zero matches ≠ "architecture is clean").
+3. Start with a small ruleset: one layer DENY, one NOCYCLES root, optional MAXCYCLICITY baseline. Grow after the first CI run produces readable volume.
+4. Member-level DENY volume can be large; type-level rollups (sample script) are better dashboards.
+
+Example starter rules live in [`samples/ci-pipeline/rules/example-layer.rules.txt`](../samples/ci-pipeline/rules/example-layer.rules.txt).
+
+---
+
+## 6. Dual-track audit (recommended)
+
+| Track | Owner | Answer |
+|-------|-------|--------|
+| **Structure** | C# Code Analyst CI | Layers, cycles, metrics |
+| **Routes / bindings** | Peer tool or tests | Shell → view → VM → data |
+
+When structure is clean and routes still fail, fix the peer track — do not invent fake DENY rules to stand in for markup.
+
+---
+
+## 7. Sample pack
+
+| Path | Role |
+|------|------|
+| [`samples/ci-pipeline/README.md`](../samples/ci-pipeline/README.md) | How to copy into your repo |
+| [`samples/ci-pipeline/action/action.yml`](../samples/ci-pipeline/action/action.yml) | GitHub composite action |
+| [`samples/ci-pipeline/workflows/codeanalyst-validate.example.yml`](../samples/ci-pipeline/workflows/codeanalyst-validate.example.yml) | Drop-in workflow skeleton |
+| [`samples/ci-pipeline/scripts/parse_validation_result.py`](../samples/ci-pipeline/scripts/parse_validation_result.py) | Text → JSON edges |
+| [`samples/ci-pipeline/scripts/merge_edges_example.py`](../samples/ci-pipeline/scripts/merge_edges_example.py) | Minimal multi-source merge + dashboard |
+| [`samples/ci-pipeline/schema/edge.schema.json`](../samples/ci-pipeline/schema/edge.schema.json) | Edge contract |
+
+Fork the pack, replace peer importers with whatever your product needs, keep Code Analyst as the structural stage. Different teams will (and should) assemble the stages differently — that is the point of sharing the pattern broadly.

--- a/Documentation/command-line-arguments.md
+++ b/Documentation/command-line-arguments.md
@@ -32,4 +32,13 @@ validation command line to the clipboard.
 
 ## Rules file syntax
 
-See [README.md](../README.md)
+See [README.md](../README.md) and [Architectural rules](architectural-rules.md).
+
+## CI and multi-source pipelines
+
+For GitHub Actions packaging, JSON edge export helpers, and using Code Analyst
+as one evidence stage among peer auditors (without pretending the graph sees every
+UI binding), see:
+
+- [CI + multi-source evidence pipeline](ci-and-multi-source-pipeline.md)
+- Sample pack: [`samples/ci-pipeline/`](../samples/ci-pipeline/README.md)

--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ To integrate the tool into a build pipeline, you can call it without a user inte
 
 [Command-line arguments](Documentation/command-line-arguments.md)
 
+For a **multi-source evidence pipeline** (Code Analyst as the structural stage, peers for UI/DI/shell, merge without silent overwrite) plus a drop-in GitHub Actions sample pack, see:
+
+[CI + multi-source evidence pipeline](Documentation/ci-and-multi-source-pipeline.md) · [`samples/ci-pipeline/`](samples/ci-pipeline/README.md)
+
 ---
 
 ## Dependency Structure Matrix (DSM)

--- a/samples/ci-pipeline/README.md
+++ b/samples/ci-pipeline/README.md
@@ -1,0 +1,53 @@
+# Sample: CI + multi-source evidence pipeline
+
+This pack turns C# Code Analyst into a **repeatable CI stage** and shows how to merge it with other auditors without pretending any single tool is omniscient.
+
+Copy what you need into your product repo. Nothing here is required for day-to-day desktop use of Code Analyst.
+
+## Quick start (structure-only)
+
+1. Write `architecture.rules.txt` (see [`rules/example-layer.rules.txt`](rules/example-layer.rules.txt)).
+2. Drop [`workflows/codeanalyst-validate.example.yml`](workflows/codeanalyst-validate.example.yml) into your `.github/workflows/` (edit solution path / rules path).
+3. On a **Windows** runner with the **.NET 10 Desktop** runtime, the job downloads a release, runs `-validate`, and uploads `validation-result.txt`.
+
+Or call the composite action from this repository (after you vendor or reference it):
+
+```yaml
+- uses: ./samples/ci-pipeline/action
+  with:
+    solution: MyApp.sln
+    rules: architecture.rules.txt
+    output-dir: artifacts/codeanalyst
+```
+
+## Multi-source hub (optional)
+
+```text
+python samples/ci-pipeline/scripts/parse_validation_result.py \
+  --input artifacts/codeanalyst/validation-result.txt \
+  --edges-out artifacts/pipeline/edges-codeanalyst.jsonl \
+  --handoff-out artifacts/pipeline/handoffs/codeanalyst.json
+
+# Your other importers write more JSONL files with the same edge shape…
+python samples/ci-pipeline/scripts/merge_edges_example.py \
+  --edges-dir artifacts/pipeline \
+  --dashboard-out artifacts/pipeline/dashboard.md
+```
+
+Schema: [`schema/edge.schema.json`](schema/edge.schema.json).  
+Design doc: [`../../Documentation/ci-and-multi-source-pipeline.md`](../../Documentation/ci-and-multi-source-pipeline.md).
+
+## Requirements
+
+| Piece | Notes |
+|-------|--------|
+| Windows x64 runner | Code Analyst is `net10.0-windows` |
+| .NET 10 Desktop runtime | Headless still loads MSBuildWorkspace / desktop bits |
+| SDK on runner | Needed so MSBuildLocator can load your solution |
+| Python 3.10+ | Only if you use the parse/merge scripts |
+
+## Honesty bar
+
+- Exit code 0 means **rules clean**, not "product wiring proven."
+- Markup-only paths (Avalonia AXAML, some WPF bindings) may contribute **zero** relationships.
+- Prefer dual-track audits: structure here, routes elsewhere.

--- a/samples/ci-pipeline/action/action.yml
+++ b/samples/ci-pipeline/action/action.yml
@@ -1,0 +1,90 @@
+name: csharp-code-analyst-validate
+description: >
+  Download a C# Code Analyst release and run headless -validate on a solution.
+  Windows runners only. Uploads raw + parsed results when requested.
+
+inputs:
+  solution:
+    description: Path to the .sln relative to the workspace (or absolute).
+    required: true
+  rules:
+    description: Path to the architectural rules text file.
+    required: true
+  output-dir:
+    description: Directory for validation-result.txt, log, and parsed JSON.
+    required: false
+    default: artifacts/codeanalyst
+  release-asset-url:
+    description: Zip URL for the desktop tool (default = latest release zip name used by upstream CI).
+    required: false
+    default: https://github.com/ATrefzer/CSharpCodeAnalyst/releases/latest/download/latest-release.zip
+  parse-results:
+    description: If true, run the sample parser into JSONL edges + handoff JSON.
+    required: false
+    default: "true"
+  continue-on-violation:
+    description: If true, exit 0 even when Code Analyst reports violations (exit 1).
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Ensure output directory
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Force -Path "${{ inputs.output-dir }}" | Out-Null
+
+    - name: Download C# Code Analyst
+      shell: pwsh
+      run: |
+        $zip = Join-Path $env:RUNNER_TEMP "codeanalyst.zip"
+        $dest = Join-Path $env:RUNNER_TEMP "codeanalyst"
+        Invoke-WebRequest -Uri "${{ inputs.release-asset-url }}" -OutFile $zip
+        if (Test-Path $dest) { Remove-Item -Recurse -Force $dest }
+        Expand-Archive -Path $zip -DestinationPath $dest -Force
+        $exe = Get-ChildItem -Path $dest -Filter CSharpCodeAnalyst.exe -Recurse | Select-Object -First 1
+        if (-not $exe) { throw "CSharpCodeAnalyst.exe not found in release zip" }
+        "CODEANALYST_EXE=$($exe.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+    - name: Run headless validation
+      shell: pwsh
+      run: |
+        $out = Join-Path "${{ inputs.output-dir }}" "validation-result.txt"
+        $log = Join-Path "${{ inputs.output-dir }}" "validation-log.txt"
+        $sln = if ([System.IO.Path]::IsPathRooted("${{ inputs.solution }}")) {
+          "${{ inputs.solution }}"
+        } else {
+          Join-Path $env:GITHUB_WORKSPACE "${{ inputs.solution }}"
+        }
+        $rules = if ([System.IO.Path]::IsPathRooted("${{ inputs.rules }}")) {
+          "${{ inputs.rules }}"
+        } else {
+          Join-Path $env:GITHUB_WORKSPACE "${{ inputs.rules }}"
+        }
+        & $env:CODEANALYST_EXE `
+          -validate `
+          "-sln:$sln" `
+          "-rules:$rules" `
+          -log-console `
+          "-log-file:$log" `
+          "-out:$out"
+        $code = $LASTEXITCODE
+        "CODEANALYST_EXIT=$code" | Out-File -FilePath $env:GITHUB_ENV -Append
+        if ($code -eq 2) { exit 2 }
+        if ($code -eq 1 -and "${{ inputs.continue-on-violation }}" -ne "true") { exit 1 }
+        exit 0
+
+    - name: Parse validation result
+      if: inputs.parse-results == 'true'
+      shell: pwsh
+      run: |
+        $script = Join-Path $env:GITHUB_ACTION_PATH ".." "scripts" "parse_validation_result.py" | Resolve-Path
+        $input = Join-Path "${{ inputs.output-dir }}" "validation-result.txt"
+        $edges = Join-Path "${{ inputs.output-dir }}" "edges-codeanalyst.jsonl"
+        $hand = Join-Path "${{ inputs.output-dir }}" "handoff-codeanalyst.json"
+        if (-not (Test-Path $input)) {
+          Write-Warning "No validation-result.txt to parse"
+          exit 0
+        }
+        python $script --input $input --edges-out $edges --handoff-out $hand

--- a/samples/ci-pipeline/action/action.yml
+++ b/samples/ci-pipeline/action/action.yml
@@ -62,14 +62,33 @@ runs:
         } else {
           Join-Path $env:GITHUB_WORKSPACE "${{ inputs.rules }}"
         }
-        & $env:CODEANALYST_EXE `
-          -validate `
-          "-sln:$sln" `
-          "-rules:$rules" `
-          -log-console `
-          "-log-file:$log" `
+        # CSharpCodeAnalyst.exe is a WinExe (GUI subsystem), not a console app. With no
+        # console attached to the calling process - the normal case on a CI runner - the
+        # plain `& $exe args` call operator does not reliably wait for it or propagate
+        # $LASTEXITCODE. Start-Process -Wait -PassThru is the reliable way to get both the
+        # exit code and the console output back. -WorkingDirectory also covers tool
+        # versions that resolve appsettings.json relative to the working directory instead
+        # of the executable's own folder.
+        $exeDir = Split-Path $env:CODEANALYST_EXE -Parent
+        $stdoutPath = Join-Path "${{ inputs.output-dir }}" "console-stdout.txt"
+        $stderrPath = Join-Path "${{ inputs.output-dir }}" "console-stderr.txt"
+        $proc = Start-Process -FilePath $env:CODEANALYST_EXE -ArgumentList @(
+          "-validate",
+          "-sln:$sln",
+          "-rules:$rules",
+          "-log-console",
+          "-log-file:$log",
           "-out:$out"
-        $code = $LASTEXITCODE
+        ) -WorkingDirectory $exeDir -NoNewWindow -Wait -PassThru `
+          -RedirectStandardOutput $stdoutPath `
+          -RedirectStandardError $stderrPath
+
+        Get-Content $stdoutPath | Write-Host
+        if ((Get-Item $stderrPath).Length -gt 0) {
+          Get-Content $stderrPath | Write-Host
+        }
+
+        $code = $proc.ExitCode
         "CODEANALYST_EXIT=$code" | Out-File -FilePath $env:GITHUB_ENV -Append
         if ($code -eq 2) { exit 2 }
         if ($code -eq 1 -and "${{ inputs.continue-on-violation }}" -ne "true") { exit 1 }

--- a/samples/ci-pipeline/rules/example-layer.rules.txt
+++ b/samples/ci-pipeline/rules/example-layer.rules.txt
@@ -1,0 +1,20 @@
+// Example architectural rules for headless CI.
+// Replace MyApp.* with paths that match YOUR graph (Tree View / advanced search).
+// Wrong prefixes silently match nothing — verify with one interactive validation first.
+// See Documentation/architectural-rules.md and Documentation/ci-and-multi-source-pipeline.md
+
+// Layer: domain/core must not depend on UI
+DENY MyApp.Core.** -> MyApp.UI.**
+
+// Optional MVVM guard: ViewModels should not construct Views
+// DENY MyApp.UI.ViewModels.** -> MyApp.UI.Views.**
+
+// Keep a chosen root free of dependency cycles (path without wildcard)
+// NOCYCLES MyApp
+// NOCYCLES MyApp.Core
+
+// Cap share of types entangled in type-graph cycles (percent)
+MAXCYCLICITY = 15
+
+// Optional hot-spot LOC budgets (methods)
+// MAXLINES MyApp.UI.ViewModels.MainShellViewModel = 120

--- a/samples/ci-pipeline/schema/edge.schema.json
+++ b/samples/ci-pipeline/schema/edge.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ATrefzer/CSharpCodeAnalyst/samples/ci-pipeline/schema/edge.schema.json",
+  "title": "Multi-source architecture edge",
+  "type": "object",
+  "required": ["kind", "from", "to", "evidence_source", "status"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Optional stable id (hash of kind|from|to|source|path|status)."
+    },
+    "kind": {
+      "type": "string",
+      "description": "Semantic relation kind.",
+      "examples": ["layer_deny", "cycle", "metric", "bind", "inject", "shell_route", "call", "tension"]
+    },
+    "from": { "type": "string" },
+    "to": { "type": "string" },
+    "evidence_source": {
+      "type": "string",
+      "description": "Importer id. Use codeanalyst for this tool.",
+      "examples": ["codeanalyst", "ui_bindings", "di_factory", "merge"]
+    },
+    "status": {
+      "type": "string",
+      "description": "Disposition from that evidence source.",
+      "examples": ["DENY", "WARN", "LIVE", "DEAD", "NOISE", "OK", "FAIL"]
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "path": {
+      "type": "string",
+      "description": "Source file, report path, or line locator."
+    },
+    "note": { "type": "string" },
+    "meta": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "rules": [
+    "No evidence_source overwrites another without tagging a tension when they conflict.",
+    "codeanalyst proves layer/cycle structure; markup bindings need a peer source."
+  ]
+}

--- a/samples/ci-pipeline/scripts/merge_edges_example.py
+++ b/samples/ci-pipeline/scripts/merge_edges_example.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Minimal multi-source merge for architecture evidence edges.
+
+Loads all *.jsonl under --edges-dir (recursively), writes a dashboard markdown
+and a combined graph.jsonl. Does not delete or rank sources — only aggregates.
+
+Use as a starting point. Real hubs add tension detection between importers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def load_jsonl(root: Path) -> list[dict[str, Any]]:
+    edges: list[dict[str, Any]] = []
+    for path in sorted(root.rglob("*.jsonl")):
+        if path.name in {"graph.jsonl", "merged.jsonl"}:
+            continue
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                edges.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return edges
+
+
+def write_dashboard(path: Path, edges: list[dict[str, Any]]) -> None:
+    by_src = Counter(e.get("evidence_source", "?") for e in edges)
+    by_kind = Counter(e.get("kind", "?") for e in edges)
+    by_status = Counter(e.get("status", "?") for e in edges)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+
+    lines = [
+        "# Architecture evidence dashboard",
+        "",
+        f"_Generated: {now}_",
+        f"_Edges: {len(edges)}_",
+        "",
+        "## By evidence_source",
+        "",
+        "| Source | Count |",
+        "|---|---|",
+    ]
+    for k, v in by_src.most_common():
+        lines.append(f"| {k} | {v} |")
+    lines += ["", "## By kind", "", "| Kind | Count |", "|---|---|"]
+    for k, v in by_kind.most_common():
+        lines.append(f"| {k} | {v} |")
+    lines += ["", "## By status", "", "| Status | Count |", "|---|---|"]
+    for k, v in by_status.most_common():
+        lines.append(f"| {k} | {v} |")
+
+    sample_deny = [e for e in edges if e.get("kind") == "layer_deny"][:15]
+    sample_cycle = [e for e in edges if e.get("kind") == "cycle"][:15]
+    if sample_deny:
+        lines += ["", "## Sample layer_deny", ""]
+        for e in sample_deny:
+            hits = (e.get("meta") or {}).get("member_hits", 1)
+            lines.append(f"- `{e.get('from')}` → `{e.get('to')}` (hits={hits})")
+    if sample_cycle:
+        lines += ["", "## Sample cycles", ""]
+        for e in sample_cycle:
+            lines.append(f"- `{e.get('from')}` → `{e.get('to')}` — {e.get('note', '')}")
+
+    lines += [
+        "",
+        "## Doctrine",
+        "",
+        "- C# Code Analyst: layers + cycles + metrics.",
+        "- Peer importers: bindings, shell routes, DI, etc.",
+        "- Merges never silently overwrite sources; conflict = tension (implement per team).",
+        "",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--edges-dir", required=True, help="Directory containing *.jsonl edge files")
+    p.add_argument("--dashboard-out", required=True, help="Markdown dashboard path")
+    p.add_argument(
+        "--merged-out",
+        default="",
+        help="Optional path for combined graph.jsonl (default: <edges-dir>/graph.jsonl)",
+    )
+    args = p.parse_args(argv)
+
+    root = Path(args.edges_dir)
+    if not root.is_dir():
+        print(f"missing edges-dir: {root}", file=sys.stderr)
+        return 2
+
+    edges = load_jsonl(root)
+    merged = Path(args.merged_out) if args.merged_out else root / "graph.jsonl"
+    merged.parent.mkdir(parents=True, exist_ok=True)
+    with merged.open("w", encoding="utf-8") as f:
+        for e in edges:
+            f.write(json.dumps(e, ensure_ascii=False) + "\n")
+
+    write_dashboard(Path(args.dashboard_out), edges)
+    print(f"edges={len(edges)} dashboard={args.dashboard_out} merged={merged}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/samples/ci-pipeline/scripts/parse_validation_result.py
+++ b/samples/ci-pipeline/scripts/parse_validation_result.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+Parse C# Code Analyst headless validation text into multi-source pipeline edges.
+
+Input is produced by:
+  CSharpCodeAnalyst.exe -validate -sln:... -rules:... -out:validation-result.txt
+
+Output:
+  - JSONL edges (one per line) matching samples/ci-pipeline/schema/edge.schema.json
+  - handoff summary JSON for hub dashboards
+
+This is tolerant text scraping until a native -out-json export exists upstream.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable
+
+
+EDGE_SOURCE = "codeanalyst"
+
+
+def edge_id(kind: str, frm: str, to: str, path: str, status: str) -> str:
+    raw = f"{kind}|{frm}|{to}|{EDGE_SOURCE}|{path}|{status}"
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def typify(path: str) -> str:
+    """Lift member paths to a type-ish path (heuristic for dashboards)."""
+    segs = path.split(".")
+    cut = len(segs)
+    for i, seg in enumerate(segs):
+        if (
+            seg.startswith("set_")
+            or seg.startswith("get_")
+            or "(" in seg
+            or seg in {".ctor", "ctor"}
+            or seg.endswith("Async") and i + 1 == len(segs)
+        ):
+            cut = i
+            break
+    return ".".join(segs[: max(cut, 1)])
+
+
+def strip_global_noise(path: str) -> str:
+    # Graph paths often look like: Assembly.global.Namespace.Type.Member
+    return path.replace(".global.", ".")
+
+
+_ARROW = re.compile(r"^(.+?) -> (.+)$")
+_CYCLE_HDR = re.compile(r"dependency cycle '([^']+)' between (\d+)", re.I)
+_METRIC = re.compile(r"MAX[A-Z]+|LOC|lines", re.I)
+
+
+def parse_validation(text: str, source_path: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    parts = re.split(r"- Rule Type:\s*", text)
+    edges: list[dict[str, Any]] = []
+    deny = 0
+    cycles = 0
+    metrics = 0
+    rule_types: Counter[str] = Counter()
+
+    for part in parts[1:]:
+        lines = [ln.rstrip() for ln in part.strip().splitlines() if ln.strip()]
+        if not lines:
+            continue
+        kind = lines[0].strip().upper()
+        rule_types[kind] += 1
+
+        if kind == "DENY":
+            for line in lines[1:]:
+                m = _ARROW.match(line.strip())
+                if not m:
+                    continue
+                frm = typify(strip_global_noise(m.group(1).strip()))
+                to = typify(strip_global_noise(m.group(2).strip()))
+                status = "DENY"
+                ekind = "layer_deny"
+                edges.append(
+                    {
+                        "id": edge_id(ekind, frm, to, source_path, status),
+                        "kind": ekind,
+                        "from": frm,
+                        "to": to,
+                        "evidence_source": EDGE_SOURCE,
+                        "status": status,
+                        "confidence": 0.95,
+                        "path": source_path,
+                        "note": "DENY rule violation",
+                    }
+                )
+                deny += 1
+
+        elif kind in {"NOCYCLES", "CYCLE", "CYCLES"}:
+            name: str | None = None
+            elems: list[str] = []
+
+            def flush() -> None:
+                nonlocal cycles
+                if not name or len(elems) < 2:
+                    return
+                for i, a in enumerate(elems):
+                    b = elems[(i + 1) % len(elems)]
+                    frm = typify(strip_global_noise(a))
+                    to = typify(strip_global_noise(b))
+                    status = "WARN"
+                    ekind = "cycle"
+                    edges.append(
+                        {
+                            "id": edge_id(ekind, frm, to, source_path, status),
+                            "kind": ekind,
+                            "from": frm,
+                            "to": to,
+                            "evidence_source": EDGE_SOURCE,
+                            "status": status,
+                            "confidence": 0.9,
+                            "path": source_path,
+                            "note": f"cycle group '{name}'",
+                            "meta": {"cycle_name": name, "elements": len(elems)},
+                        }
+                    )
+                    cycles += 1
+
+            for line in lines[1:]:
+                m = _CYCLE_HDR.search(line)
+                if m:
+                    flush()
+                    name = m.group(1)
+                    elems = []
+                    continue
+                # Element lines are typically fully qualified graph paths without " -> "
+                if " -> " not in line and line.count(".") >= 1 and not line.startswith("Found"):
+                    elems.append(line.strip())
+            flush()
+
+        else:
+            # Metric / other rule blocks — keep a compact summary edge per block
+            header = " ".join(lines[:3])[:240]
+            if _METRIC.search(kind) or _METRIC.search(header):
+                frm = f"rule:{kind}"
+                to = header
+                status = "WARN"
+                ekind = "metric"
+                edges.append(
+                    {
+                        "id": edge_id(ekind, frm, to, source_path, status),
+                        "kind": ekind,
+                        "from": frm,
+                        "to": to[:120],
+                        "evidence_source": EDGE_SOURCE,
+                        "status": status,
+                        "confidence": 0.8,
+                        "path": source_path,
+                        "note": header,
+                    }
+                )
+                metrics += 1
+
+    # De-dupe type-level DENY pairs (member expansion is noisy for dashboards)
+    dedup: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+    collapsed = 0
+    for e in edges:
+        if e["kind"] != "layer_deny":
+            key = (e["kind"], e["from"], e["to"], e.get("note", ""))
+            dedup[key] = e
+            continue
+        key = (e["kind"], e["from"], e["to"], "DENY")
+        if key in dedup:
+            collapsed += 1
+            prev = dedup[key]
+            prev["meta"] = prev.get("meta") or {}
+            prev["meta"]["member_hits"] = int(prev["meta"].get("member_hits", 1)) + 1
+        else:
+            e = dict(e)
+            e["meta"] = {"member_hits": 1}
+            dedup[key] = e
+
+    out_edges = list(dedup.values())
+    handoff = {
+        "source": EDGE_SOURCE,
+        "status": "ok" if out_edges or "No violation" in text or not parts[1:] else "ok",
+        "deny_edges": deny,
+        "deny_type_pairs": sum(1 for e in out_edges if e["kind"] == "layer_deny"),
+        "cycle_edges": cycles,
+        "metric_edges": metrics,
+        "edge_count": len(out_edges),
+        "collapsed_member_denies": collapsed,
+        "rule_types": dict(rule_types),
+        "input": source_path,
+    }
+    return out_edges, handoff
+
+
+def write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--input", required=True, help="validation-result.txt from -out:")
+    p.add_argument("--edges-out", required=True, help="JSONL edge output path")
+    p.add_argument("--handoff-out", required=True, help="handoff summary JSON path")
+    args = p.parse_args(argv)
+
+    src = Path(args.input)
+    if not src.is_file():
+        print(f"missing input: {src}", file=sys.stderr)
+        return 2
+
+    text = src.read_text(encoding="utf-8", errors="replace")
+    edges, handoff = parse_validation(text, str(src).replace("\\", "/"))
+    write_jsonl(Path(args.edges_out), edges)
+    Path(args.handoff_out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.handoff_out).write_text(json.dumps(handoff, indent=2), encoding="utf-8")
+    print(json.dumps(handoff, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/samples/ci-pipeline/workflows/codeanalyst-validate.example.yml
+++ b/samples/ci-pipeline/workflows/codeanalyst-validate.example.yml
@@ -51,15 +51,38 @@ jobs:
       - name: Validate architecture
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force -Path artifacts/codeanalyst | Out-Null
+          $outDir = "artifacts/codeanalyst"
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
           $exe = Get-ChildItem tools/codeanalyst -Filter CSharpCodeAnalyst.exe -Recurse | Select-Object -First 1
-          & $exe.FullName `
-            -validate `
-            "-sln:$env:GITHUB_WORKSPACE\MyApp.sln" `
-            "-rules:$env:GITHUB_WORKSPACE\architecture.rules.txt" `
-            -log-console `
-            "-log-file:$env:GITHUB_WORKSPACE\artifacts\codeanalyst\validation-log.txt" `
-            "-out:$env:GITHUB_WORKSPACE\artifacts\codeanalyst\validation-result.txt"
+
+          $argList = @(
+            "-validate",
+            "-sln:$env:GITHUB_WORKSPACE\MyApp.sln",
+            "-rules:$env:GITHUB_WORKSPACE\architecture.rules.txt",
+            "-log-console",
+            "-log-file:$env:GITHUB_WORKSPACE\$outDir\validation-log.txt",
+            "-out:$env:GITHUB_WORKSPACE\$outDir\validation-result.txt"
+          )
+
+          # CSharpCodeAnalyst.exe is a WinExe (GUI subsystem). The plain `& $exe args` call
+          # operator does not reliably wait or propagate the exit code when no console is
+          # attached (the normal case on a CI runner). Start-Process -Wait -PassThru is the
+          # reliable way to invoke it headlessly; -WorkingDirectory also covers tool
+          # versions that resolve appsettings.json relative to the working directory.
+          $proc = Start-Process -FilePath $exe.FullName -ArgumentList $argList -WorkingDirectory $exe.DirectoryName -NoNewWindow -Wait -PassThru `
+            -RedirectStandardOutput "$outDir\console-stdout.txt" `
+            -RedirectStandardError "$outDir\console-stderr.txt"
+
+          Get-Content "$outDir\console-stdout.txt" | Write-Host
+          if ((Get-Item "$outDir\console-stderr.txt").Length -gt 0) {
+            Get-Content "$outDir\console-stderr.txt" | Write-Host
+          }
+
+          $code = $proc.ExitCode
+          Write-Host "CSharpCodeAnalyst -validate exit code: $code"
+          if ($code -ne 0) {
+            exit $code
+          }
 
       - name: Upload results
         if: always()

--- a/samples/ci-pipeline/workflows/codeanalyst-validate.example.yml
+++ b/samples/ci-pipeline/workflows/codeanalyst-validate.example.yml
@@ -1,0 +1,69 @@
+# Copy to your repo as .github/workflows/codeanalyst-validate.yml and edit paths.
+# Requires a Windows runner (.NET 10 Desktop runtime + SDK for MSBuildLocator).
+name: Architecture guardrails (C# Code Analyst)
+
+on:
+  pull_request:
+    paths:
+      - "**/*.cs"
+      - "**/*.csproj"
+      - "**/*.sln"
+      - "architecture.rules.txt"
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      # Install desktop runtime if the hosted image needs it for the published exe.
+      - name: Ensure .NET Desktop runtime
+        shell: pwsh
+        run: |
+          # Hosted images usually ship SDKs; this is a safe no-op when present.
+          dotnet --list-runtimes
+
+      - name: Restore (helps MSBuild load multi-project solutions)
+        run: dotnet restore MyApp.sln
+
+      # Option A: vendor this composite action from a checkout of CSharpCodeAnalyst
+      # - uses: path/to/CSharpCodeAnalyst/samples/ci-pipeline/action
+      #   with:
+      #     solution: MyApp.sln
+      #     rules: architecture.rules.txt
+
+      # Option B: inline (no vendored action)
+      - name: Download C# Code Analyst
+        shell: pwsh
+        run: |
+          $url = "https://github.com/ATrefzer/CSharpCodeAnalyst/releases/latest/download/latest-release.zip"
+          Invoke-WebRequest $url -OutFile codeanalyst.zip
+          Expand-Archive codeanalyst.zip -DestinationPath tools/codeanalyst -Force
+
+      - name: Validate architecture
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path artifacts/codeanalyst | Out-Null
+          $exe = Get-ChildItem tools/codeanalyst -Filter CSharpCodeAnalyst.exe -Recurse | Select-Object -First 1
+          & $exe.FullName `
+            -validate `
+            "-sln:$env:GITHUB_WORKSPACE\MyApp.sln" `
+            "-rules:$env:GITHUB_WORKSPACE\architecture.rules.txt" `
+            -log-console `
+            "-log-file:$env:GITHUB_WORKSPACE\artifacts\codeanalyst\validation-log.txt" `
+            "-out:$env:GITHUB_WORKSPACE\artifacts\codeanalyst\validation-result.txt"
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeanalyst-validation
+          path: artifacts/codeanalyst/


### PR DESCRIPTION
## Summary

This PR donates a **multi-source evidence pipeline** pattern for people who already use C# Code Analyst in CI — and for teams who will invent different peer stages.

It is not a claim of ownership over the concept; others will (and should) compose stages differently. The useful part is making headless validate easy to plug into a larger honesty model:

- **Code Analyst** = structural truth (layers, cycles, metrics)
- **Peer importers** = bindings, shell routes, DI, etc. (whatever the product needs)
- **Merge rule** = never silently overwrite another source; conflict ⇒ tension, not a fake green

Produced against a real monorepo workflow (Windows, release zip, DENY/NOCYCLES text out → type-level edges), then generalized so this repository can ship it for everyone.

## What is in the PR

- `Documentation/ci-and-multi-source-pipeline.md` — doctrine + pipeline shape
- `samples/ci-pipeline/` — copy-ready pack:
  - GitHub composite action (download latest-release.zip, run `-validate`)
  - example workflow
  - starter rules file
  - `parse_validation_result.py` (text → JSONL edges + handoff summary)
  - `merge_edges_example.py` (minimal multi-source dashboard)
  - edge JSON schema
- README / architectural-rules / CLI docs link the new guide

No runtime app code is changed. GPL-3 same as the project.

## Why text scrape parsers

Headless `-out:` is human-readable today. The sample parser is explicitly a bridge until a native `-out-json` / SARIF export exists. Happy to iterate on a machine-readable output format in a follow-up if you want that upstream.

## Test plan

- [x] Python scripts `py_compile` clean
- [x] Parser smoked on a tiny DENY + NOCYCLES fixture (edges + handoff counts)
- [ ] Maintainer: skim docs tone / sample paths
- [ ] Optional: run composite action (or workflow skeleton) against this solution + a small rules file on windows-latest

## Optional follow-ups (not in this PR)

- First-class `-out-json:<file>` (or SARIF) from `-validate`
- Publish the composite action as a versioned release artifact
- Self-dogfood validate of `CSharpCodeAnalyst.sln` in this repo's CI

Thanks for the tool — hoped sharing the pipeline shape would help other teams plug it into their own honesty model without reinventing the CI glue.

Made with [Cursor](https://cursor.com)